### PR TITLE
Renaming functions and parameters

### DIFF
--- a/src/Infrastructure/EntityRepository.php
+++ b/src/Infrastructure/EntityRepository.php
@@ -18,16 +18,16 @@ class EntityRepository extends BaseRepository
 
 
     /**
-     * @param $objectId
+     * @param $domainId
      *
      * @return int
      */
-    public function objectIdExists($objectId)
+    public function domainIdExists($domainId)
     {
         return (int) $this->createQueryBuilder('t')
-            ->select('COUNT(t.objectId)')
-            ->where('t.objectId = :objectId')
-            ->setParameter('objectId', $objectId)
+            ->select('COUNT(t.domainId)')
+            ->where('t.domainId = :domainId')
+            ->setParameter('domainId', $domainId)
             ->getQuery()
             ->getSingleScalarResult();
     }

--- a/src/Infrastructure/EntityRepository.php
+++ b/src/Infrastructure/EntityRepository.php
@@ -11,7 +11,7 @@ class EntityRepository extends BaseRepository
      *
      * @return Entity|null
      */
-    public function findByObjectId($objectId)
+    public function findByDomainId($objectId)
     {
         return $this->findOneBy(['objectId' => $objectId]);
     }

--- a/src/Infrastructure/EntityRepository.php
+++ b/src/Infrastructure/EntityRepository.php
@@ -7,13 +7,13 @@ class EntityRepository extends BaseRepository
 {
 
     /**
-     * @param string $objectId
+     * @param string $domainId
      *
      * @return Entity|null
      */
-    public function findByDomainId($objectId)
+    public function findByDomainId($domainId)
     {
-        return $this->findOneBy(['objectId' => $objectId]);
+        return $this->findOneBy(['domainId' => $domainId]);
     }
 
 

--- a/src/Traits/ManagesEntities.php
+++ b/src/Traits/ManagesEntities.php
@@ -102,13 +102,13 @@ trait ManagesEntities
 
 
     /**
-     * @param string $className
+     * @param string $entityClassName
      *
      * @return ObjectRepository
      */
-    private function getEntityRepository($className)
+    private function getEntityRepository($entityClassName)
     {
-        return $this->getEntityManager()->getRepository($className);
+        return $this->getEntityManager()->getRepository($entityClassName);
     }
 
 


### PR DESCRIPTION
- Rename EntityRepository::objectIdExists($objectId) to EntityRepository::domainIdExists($domainId), and the query => objectId => domainId
- Rename EntityRepository::findByObjectId() => findByDomainId()
- Rename in the ManagesEntities trait getEntityRepository($className) => $className => $entityClassName parameter
