### PR TITLE
Port the `ThrottleRequests` middleware from Laravel as it is missing in Lumen

### DIFF
--- a/src/Middleware/ThrottleRequests.php
+++ b/src/Middleware/ThrottleRequests.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Nord\Lumen\Core\Middleware;
+
+use Closure;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Http\Request;
+use Nord\Lumen\Core\Traits\CreatesHttpResponses;
+use Symfony\Component\HttpFoundation\Response;
+
+class ThrottleRequests
+{
+    use CreatesHttpResponses;
+
+    /**
+     * The rate limiter instance.
+     *
+     * @var RateLimiter
+     */
+    private $rateLimiter;
+
+    /**
+     * Create a new request throttler.
+     *
+     * @param RateLimiter $rateLimiter
+     */
+    public function __construct(RateLimiter $rateLimiter)
+    {
+        $this->rateLimiter = $rateLimiter;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @param int     $maxAttempts
+     * @param int     $decayMinutes
+     *
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+    {
+        $key = $this->resolveRequestSignature($request);
+
+        if ($this->rateLimiter->tooManyAttempts($key, $maxAttempts, $decayMinutes)) {
+            return $this->buildResponse($key, $maxAttempts);
+        }
+
+        $this->rateLimiter->hit($key, $decayMinutes);
+
+        $response = $next($request);
+
+        return $this->addHeaders(
+            $response, $maxAttempts,
+            $this->calculateRemainingAttempts($key, $maxAttempts)
+        );
+    }
+
+    /**
+     * Resolve request signature.
+     *
+     * @param Request $request
+     *
+     * @return string
+     */
+    protected function resolveRequestSignature($request)
+    {
+        return sha1(
+            $request->method() .
+            '|' . $request->server('SERVER_NAME') .
+            '|' . $request->path() .
+            '|' . $request->ip()
+        );
+    }
+
+    /**
+     * Create a 'too many attempts' response.
+     *
+     * @param string $key
+     * @param int    $maxAttempts
+     *
+     * @return Response
+     */
+    protected function buildResponse($key, $maxAttempts)
+    {
+        $response = $this->errorResponse('Too Many Requests', [], 429);
+
+        $retryAfter = $this->rateLimiter->availableIn($key);
+
+        return $this->addHeaders(
+            $response, $maxAttempts,
+            $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),
+            $retryAfter
+        );
+    }
+
+    /**
+     * Add the limit header information to the given response.
+     *
+     * @param Response $response
+     * @param int      $maxAttempts
+     * @param int      $remainingAttempts
+     * @param int|null $retryAfter
+     *
+     * @return Response
+     */
+    protected function addHeaders(Response $response, $maxAttempts, $remainingAttempts, $retryAfter = null)
+    {
+        $headers = [
+            'X-RateLimit-Limit' => $maxAttempts,
+            'X-RateLimit-Remaining' => $remainingAttempts,
+        ];
+
+        if (!is_null($retryAfter)) {
+            $headers['Retry-After'] = $retryAfter;
+        }
+
+        $response->headers->add($headers);
+
+        return $response;
+    }
+
+    /**
+     * Calculate the number of remaining attempts.
+     *
+     * @param string   $key
+     * @param int      $maxAttempts
+     * @param int|null $retryAfter
+     *
+     * @return int
+     */
+    protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
+    {
+        if (!is_null($retryAfter)) {
+            return 0;
+        }
+
+        return $this->rateLimiter->retriesLeft($key, $maxAttempts);
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds new middleware for throttling requests
